### PR TITLE
Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,18 +34,12 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
         django: ['3.2', '4.1', '4.2']
-        wagtail: ['4.1', '4.2', '5.0', '5.1']
-        include:
-          - python: '3.8'
-            django: '3.2'
-            wagtail: '3.0'
+        wagtail: ['4.1', '5.1', '5.2']
         exclude:
           - django: '4.2'
             wagtail: '4.1'
-          - django: '4.2'
-            wagtail: '4.2'
           - python: '3.11'
             django: '3.2'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 - Add support for Wagtail 5.1
 - Add support for Wagtail 5.1+
+- Drop tests for Wagtail 4.2 and 5.0 as they have reached EOL
 - Bring back token generation for sharing links, this work was proposed here but not accepted: https://github.com/cfpb/wagtail-sharing/pull/47
 
 ## 2.10 - 2023-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 - Add support for Wagtail 5.1
+- Add support for Wagtail 5.1+
+- Bring back token generation for sharing links, this work was proposed here but not accepted: https://github.com/cfpb/wagtail-sharing/pull/47
 
 ## 2.10 - 2023-08-16
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 skipsdist=True
 envlist=
-    lint,
-    python{3.8}-django{3.2}-wagtail{3.0},
-    python{3.11}-django{4.1}-wagtail{4.1,4.2,5.0,5.1},
-    python{3.11}-django{4.2}-wagtail{5.0,5.1},
+    lint
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}
+    python3.11-django4.1-wagtail{4.1,5.1,5.2}
+    python3.11-django4.2-wagtail{5.1,5.2}
     coverage
 
 [testenv]
@@ -14,16 +14,16 @@ commands=
 
 basepython=
     python3.8: python3.8
+    python3.9: python3.9
+    python3.10: python3.10
     python3.11: python3.11
 
 deps=
     django3.2: Django>=3.2,<3.3
     django4.1: Django>=4.1,<4.2
-    wagtail3.0: wagtail>=3.0,<4.0
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail4.2: wagtail>=4.2,<4.3
-    wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
 
 [testenv:lint]
 basepython=python3.8

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -39,8 +39,10 @@ class TestAddSharingLink(TestCase):
             links = add_sharing_link(self.page, **kwargs)
             button = next(links)
             self.assertEqual(button.url, url)
+
+            expected_title = button.attrs["aria-label"] if WAGTAIL_VERSION >= (5, 2) else button.attrs["title"]
             self.assertIn(
-                self.page.get_admin_display_title(), button.attrs["title"]
+                self.page.get_admin_display_title(), expected_title
             )
 
 

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -26,7 +26,11 @@ class TestAddSharingLink(TestCase):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=None
         ):
-            kwargs = {"user": self.user} if WAGTAIL_VERSION >= (5, 2) else {"page_perms": self.page_perms}
+            kwargs = (
+                {"user": self.user}
+                if WAGTAIL_VERSION >= (5, 2)
+                else {"page_perms": self.page_perms}
+            )
             links = add_sharing_link(self.page, **kwargs)
             self.assertFalse(list(links))
 
@@ -35,15 +39,21 @@ class TestAddSharingLink(TestCase):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=url
         ):
-            kwargs = {"user": self.user} if WAGTAIL_VERSION >= (5, 2) else {"page_perms": self.page_perms}
+            kwargs = (
+                {"user": self.user}
+                if WAGTAIL_VERSION >= (5, 2)
+                else {"page_perms": self.page_perms}
+            )
             links = add_sharing_link(self.page, **kwargs)
             button = next(links)
             self.assertEqual(button.url, url)
 
-            expected_title = button.attrs["aria-label"] if WAGTAIL_VERSION >= (5, 2) else button.attrs["title"]
-            self.assertIn(
-                self.page.get_admin_display_title(), expected_title
+            expected_title = (
+                button.attrs["aria-label"]
+                if WAGTAIL_VERSION >= (5, 2)
+                else button.attrs["title"]
             )
+            self.assertIn(self.page.get_admin_display_title(), expected_title)
 
 
 class TestAddSharingBanner(TestCase):

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -4,6 +4,9 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 
+from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail.test.utils.wagtail_tests import WagtailTestUtils
+
 from wagtailsharing.tests.shareable_routable_testapp.models import TestPage
 from wagtailsharing.wagtail_hooks import (
     add_sharing_banner,
@@ -17,12 +20,14 @@ class TestAddSharingLink(TestCase):
     def setUp(self):
         self.page = TestPage(title="title", slug="slug")
         self.page_perms = Mock()
+        self.user = WagtailTestUtils.create_test_user()
 
     def test_no_link_no_button(self):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=None
         ):
-            links = add_sharing_link(self.page, self.page_perms)
+            kwargs = {"user": self.user} if WAGTAIL_VERSION >= (5, 2) else {"page_perms": self.page_perms}
+            links = add_sharing_link(self.page, **kwargs)
             self.assertFalse(list(links))
 
     def test_link_makes_button(self):
@@ -30,7 +35,8 @@ class TestAddSharingLink(TestCase):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=url
         ):
-            links = add_sharing_link(self.page, self.page_perms)
+            kwargs = {"user": self.user} if WAGTAIL_VERSION >= (5, 2) else {"page_perms": self.page_perms}
+            links = add_sharing_link(self.page, **kwargs)
             button = next(links)
             self.assertEqual(button.url, url)
             self.assertIn(

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -45,23 +45,42 @@ else:
     modeladmin_register(SharingSiteModelAdmin)
 
 
-@hooks.register("register_page_header_buttons")
-@hooks.register("register_page_listing_more_buttons")
-def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
-    sharing_url = get_sharing_url(page)
+if WAGTAIL_VERSION >= (5, 2):
+    @hooks.register("register_page_header_buttons")
+    @hooks.register("register_page_listing_more_buttons")
+    def add_sharing_link(page, user, is_parent=False, next_url=None):
+        sharing_url = get_sharing_url(page)
 
-    if sharing_url:
-        yield wagtailadmin_widgets.Button(
-            "View sharing link",
-            sharing_url,
-            icon_name="draft",
-            attrs={
-                "title": _("View shared revision of '{}'").format(
-                    page.get_admin_display_title()
-                ),
-            },
-            priority=90,
-        )
+        if sharing_url:
+            yield wagtailadmin_widgets.Button(
+                "View sharing link",
+                sharing_url,
+                icon_name="draft",
+                attrs={
+                    "title": _("View shared revision of '{}'").format(
+                        page.get_admin_display_title()
+                    ),
+                },
+                priority=90,
+            )
+else:
+    @hooks.register("register_page_header_buttons")
+    @hooks.register("register_page_listing_more_buttons")
+    def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
+        sharing_url = get_sharing_url(page)
+
+        if sharing_url:
+            yield wagtailadmin_widgets.Button(
+                "View sharing link",
+                sharing_url,
+                icon_name="draft",
+                attrs={
+                    "title": _("View shared revision of '{}'").format(
+                        page.get_admin_display_title()
+                    ),
+                },
+                priority=90,
+            )
 
 
 @hooks.register("after_serve_shared_page")

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -46,6 +46,7 @@ else:
 
 
 if WAGTAIL_VERSION >= (5, 2):
+
     @hooks.register("register_page_header_buttons")
     @hooks.register("register_page_listing_more_buttons")
     def add_sharing_link(page, user, is_parent=False, next_url=None):
@@ -63,7 +64,9 @@ if WAGTAIL_VERSION >= (5, 2):
                 },
                 priority=90,
             )
+
 else:
+
     @hooks.register("register_page_header_buttons")
     @hooks.register("register_page_listing_more_buttons")
     def add_sharing_link(page, page_perms, is_parent=False, next_url=None):


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Includes PR: https://github.com/torchbox-forks/wagtail-sharing/pull/3

## Upgrade considerations

- [Hooks for page listing and page header buttons no longer accept a page_perms argument](https://docs.wagtail.org/en/stable/releases/5.2.html#hooks-for-page-listing-and-page-header-buttons-no-longer-accept-a-page-perms-argument)

### Other changes

- Update test matrices
- Update changelog
- Drop tests for Wagtail 4.2 and 5.0 as they have reached EOL